### PR TITLE
New updates:

### DIFF
--- a/recipes-bsp/drivers/dreambox-blindscan-utils.bb
+++ b/recipes-bsp/drivers/dreambox-blindscan-utils.bb
@@ -22,4 +22,3 @@ do_install() {
 }
 
 INHIBIT_PACKAGE_STRIP = "1"
-PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-bsp/drivers/dreambox-blindscan-utils.bb
+++ b/recipes-bsp/drivers/dreambox-blindscan-utils.bb
@@ -6,10 +6,9 @@ RPROVIDES_${PN} += "virtual/blindscan-dvbs virtual/blindscan-dvbc"
 
 DEPENDS = "ncurses"
 
-PV = "${@bb.utils.contains("MACHINE", "dm800", "1.9", "1.12", d)}"
+PV = "1.9"
 
-SRC_URI_dm800 += "http://dreamboxupdate.com/download/opendreambox/2.0.0/blindscan-utils/blindscan-utils_1.9_${DEFAULTTUNE}.tar.bz2;name=${DEFAULTTUNE}-denzil"
-SRC_URI += "http://dreamboxupdate.com/download/opendreambox/2.2.0/blindscan-utils/${PV}/${DEFAULTTUNE}/2acb58192434f308bfed6879c51d5d6e/blindscan-utils_${PV}_${DEFAULTTUNE}.tar.xz;name=${DEFAULTTUNE}-dora"
+SRC_URI = "http://dreamboxupdate.com/download/opendreambox/2.0.0/blindscan-utils/blindscan-utils_${PV}_${DEFAULTTUNE}.tar.bz2;name=${DEFAULTTUNE}-denzil"
 
 S = "${WORKDIR}/blindscan-utils_${PV}_${DEFAULTTUNE}"
 


### PR DESCRIPTION
New updates:

- Cleanup blindscan recipes and get rid of COMPATIBLE_MACHINE and MACHINE_ARCH as we could use the binaries per architecture and even other boxes.
- Introduce STB_PLATFORM for better Python management with branding module, this is compatible with getMachineBuild() which OE-A has.
- Introduce BLINDSCAN_BINARY which I'm going to use it as getBlindscanBin() in branding module for fast binary detection, default value is blindscan.